### PR TITLE
Add DBLP SPARQL support

### DIFF
--- a/SPARQL_NOTES.md
+++ b/SPARQL_NOTES.md
@@ -1,0 +1,10 @@
+# DBLP SPARQL Integration
+
+This extension now performs author search and publication lookup using the [DBLP SPARQL endpoint](https://github.com/dblp/kg/wiki).
+
+## Advantages
+
+- **Flexible queries** – SPARQL allows more precise filtering such as by venue or year.
+- **Consistent metadata** – Results are pulled from the official knowledge graph so the information stays up‑to‑date.
+- **One endpoint** – Author search and publication details can be fetched using the same API.
+


### PR DESCRIPTION
## Summary
- integrate DBLP SPARQL endpoint for author search and publication retrieval
- expose helper functions for running SPARQL queries
- allow switching via `USE_SPARQL` flag
- document advantages of using the SPARQL API

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68409ccb1adc8329adfc1f12c16d7332