### PR TITLE
Prefer event-level DBLP streams when deriving venue metadata

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -2070,14 +2070,19 @@ async function fetchPublicationsFromDblp(
         const numericYear = year ? parseInt(year, 10) : null;
 
         const conferenceCandidates: string[] = [];
-        const confSeriesMatch = pubUrl.match(/^db\/conf\/([a-zA-Z][\w-]*)\//);
-        if (confSeriesMatch?.[1]) {
-          conferenceCandidates.push(confSeriesMatch[1]);
-        }
+        const addCandidate = (candidate: string | undefined | null) => {
+          if (!candidate) return;
+          const normalized = candidate.toLowerCase();
+          if (!conferenceCandidates.includes(normalized)) {
+            conferenceCandidates.push(normalized);
+          }
+        };
+
         const confFileMatch = pubUrl.match(/^db\/conf\/[^/]+\/([a-zA-Z][\w-]*?)(\d{4}.*)?\.html/);
-        if (confFileMatch?.[1] && !conferenceCandidates.includes(confFileMatch[1])) {
-          conferenceCandidates.push(confFileMatch[1]);
-        }
+        addCandidate(confFileMatch?.[1] ?? null);
+
+        const confSeriesMatch = pubUrl.match(/^db\/conf\/([a-zA-Z][\w-]*)\//);
+        addCandidate(confSeriesMatch?.[1] ?? null);
 
         for (const candidate of conferenceCandidates) {
           streamMeta = await resolveDblpStreamMetadata("conf", candidate, { year: numericYear });


### PR DESCRIPTION
## Summary
- prefer DBLP event-level stream identifiers before the parent series when resolving publication metadata
- normalize candidate collection to avoid duplicate lookups while retaining the series as a fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69025120c1c08329b44529216e3b6450